### PR TITLE
Added Non blocking open3d  

### DIFF
--- a/display.py
+++ b/display.py
@@ -34,14 +34,11 @@ class Display:
 		if tripoints3d is not None:
 			pcd = o3d.geometry.PointCloud()
 			pcd.points = o3d.utility.Vector3dVector(tripoints3d)
-			# o3d.visualization.draw_geometries([pcd])
-			# vis = o3d.visualization.Visualizer()
-			vis = o3d.visualization.Visualizer()
-			vis.create_window()
-			vis.add_geometry(pcd)
-			# vis.destroy_window()
-			vis.update_renderer()
-			vis.poll_events()
+			visualizer = o3d.visualization.Visualizer()
+			visualizer.create_window()
+			visualizer.add_geometry(pcd)
+			visualizer.update_renderer()
+			visualizer.poll_events()
 			time.sleep(0.1)
 
 		"""

--- a/display.py
+++ b/display.py
@@ -4,7 +4,7 @@ import open3d as o3d
 import matplotlib.pyplot as plt
 from matplotlib.pylab import *
 from mpl_toolkits.mplot3d import Axes3D
-
+import time
 
 
 class Display:
@@ -34,7 +34,15 @@ class Display:
 		if tripoints3d is not None:
 			pcd = o3d.geometry.PointCloud()
 			pcd.points = o3d.utility.Vector3dVector(tripoints3d)
-			o3d.visualization.draw_geometries([pcd])
+			# o3d.visualization.draw_geometries([pcd])
+			# vis = o3d.visualization.Visualizer()
+			vis = o3d.visualization.Visualizer()
+			vis.create_window()
+			vis.add_geometry(pcd)
+			# vis.destroy_window()
+			vis.update_renderer()
+			vis.poll_events()
+			time.sleep(0.1)
 
 		"""
 		# matplotlib


### PR DESCRIPTION
I've changed the open3d `draw_geometries` function in a non-blocking fashion so that we  don't need to give a user input to go to the next frame